### PR TITLE
Remove dependency on color lib and upgrade version to 2.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var MersenneTwister = require('mersenne-twister');
 var paperGen = require('./paper')
-var Color = require('color')
 var colors = require('./colors')
 var shapeCount = 4
 var svgns = 'http://www.w3.org/2000/svg'
@@ -70,9 +69,94 @@ function genColor(colors) {
 var wobble = 30
 function hueShift(colors, generator) {
   var amount = (generator.random() * 30) - (wobble / 2)
-  return colors.map(function(hex) {
-    var color = Color(hex)
-    color.rotate(amount)
-    return color.hexString()
-  })
+  var rotate = (hex) => colorRotate(hex, amount)
+  return colors.map(rotate)
+}
+
+function colorRotate(hex, degrees) {
+  var hsl = hexToHSL(hex)
+  var hue = hsl.h
+  hue = (hue + degrees) % 360;
+  hue = hue < 0 ? 360 + hue : hue;
+  hsl.h = hue;
+  return HSLToHex(hsl);
+}
+
+function hexToHSL(hex) {
+  // Convert hex to RGB first
+  var r = "0x" + hex[1] + hex[2];
+  var g = "0x" + hex[3] + hex[4];
+  var b = "0x" + hex[5] + hex[6];
+  // Then to HSL
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  var cmin = Math.min(r,g,b),
+      cmax = Math.max(r,g,b),
+      delta = cmax - cmin,
+      h = 0,
+      s = 0,
+      l = 0;
+
+  if (delta == 0)
+    h = 0;
+  else if (cmax == r)
+    h = ((g - b) / delta) % 6;
+  else if (cmax == g)
+    h = (b - r) / delta + 2;
+  else
+    h = (r - g) / delta + 4;
+
+  h = Math.round(h * 60);
+
+  if (h < 0)
+    h += 360;
+
+  l = (cmax + cmin) / 2;
+  s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+  s = +(s * 100).toFixed(1);
+  l = +(l * 100).toFixed(1);
+
+  return {h, s, l}
+}
+
+function HSLToHex(hsl) {
+  var {h, s, l} = hsl
+  s /= 100;
+  l /= 100;
+
+  let c = (1 - Math.abs(2 * l - 1)) * s,
+      x = c * (1 - Math.abs((h / 60) % 2 - 1)),
+      m = l - c/2,
+      r = 0,
+      g = 0, 
+      b = 0; 
+
+  if (0 <= h && h < 60) {
+    r = c; g = x; b = 0;
+  } else if (60 <= h && h < 120) {
+    r = x; g = c; b = 0;
+  } else if (120 <= h && h < 180) {
+    r = 0; g = c; b = x;
+  } else if (180 <= h && h < 240) {
+    r = 0; g = x; b = c;
+  } else if (240 <= h && h < 300) {
+    r = x; g = 0; b = c;
+  } else if (300 <= h && h < 360) {
+    r = c; g = 0; b = x;
+  }
+  // Having obtained RGB, convert channels to hex
+  r = Math.round((r + m) * 255).toString(16);
+  g = Math.round((g + m) * 255).toString(16);
+  b = Math.round((b + m) * 255).toString(16);
+
+  // Prepend 0s, if necessary
+  if (r.length == 1)
+    r = "0" + r;
+  if (g.length == 1)
+    g = "0" + g;
+  if (b.length == 1)
+    b = "0" + b;
+
+  return "#" + r + g + b;
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "color": "^0.11.3",
     "mersenne-twister": "^1.1.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/jazzicon",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Jazzy deterministic identicons for a more entertaining future",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

This hoists up the little bit of color manipulation logic needed from the color library in order to remove that dependency. The bulk of jazzicon's bundle size came from color so this significantly reduced it (~20Kb reduction).

It also increases the major version number to mark the change.

## Testing

Tested in Safari, Firefox, and Chrome (via https://celowallet.app) on known addresses and can confirm they render correctly.