### PR TITLE
Add NPM lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "@metamask/jazzicon",
+  "version": "2.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@metamask/jazzicon",
+      "version": "2.1.0",
+      "license": "ISC",
+      "dependencies": {
+        "mersenne-twister": "^1.1.0"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/mersenne-twister": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mersenne-twister/-/mersenne-twister-1.1.0.tgz",
+      "integrity": "sha512-mUYWsMKNrm4lfygPkL3OfGzOPTR2DBlTkBNHM//F6hGp8cLThY897crAlk3/Jo17LEOOjQUrNAx6DvgO77QJkA=="
+    }
+  }
+}


### PR DESCRIPTION
It's customary for our projects to version-control the lockfile that the package manager produces.