### PR TITLE
Revert "Remove dependency on color lib and upgrade version to 2.1.0"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var MersenneTwister = require('mersenne-twister');
 var paperGen = require('./paper')
+var Color = require('color')
 var colors = require('./colors')
 var shapeCount = 4
 var svgns = 'http://www.w3.org/2000/svg'
@@ -69,94 +70,9 @@ function genColor(colors) {
 var wobble = 30
 function hueShift(colors, generator) {
   var amount = (generator.random() * 30) - (wobble / 2)
-  var rotate = (hex) => colorRotate(hex, amount)
-  return colors.map(rotate)
-}
-
-function colorRotate(hex, degrees) {
-  var hsl = hexToHSL(hex)
-  var hue = hsl.h
-  hue = (hue + degrees) % 360;
-  hue = hue < 0 ? 360 + hue : hue;
-  hsl.h = hue;
-  return HSLToHex(hsl);
-}
-
-function hexToHSL(hex) {
-  // Convert hex to RGB first
-  var r = "0x" + hex[1] + hex[2];
-  var g = "0x" + hex[3] + hex[4];
-  var b = "0x" + hex[5] + hex[6];
-  // Then to HSL
-  r /= 255;
-  g /= 255;
-  b /= 255;
-  var cmin = Math.min(r,g,b),
-      cmax = Math.max(r,g,b),
-      delta = cmax - cmin,
-      h = 0,
-      s = 0,
-      l = 0;
-
-  if (delta == 0)
-    h = 0;
-  else if (cmax == r)
-    h = ((g - b) / delta) % 6;
-  else if (cmax == g)
-    h = (b - r) / delta + 2;
-  else
-    h = (r - g) / delta + 4;
-
-  h = Math.round(h * 60);
-
-  if (h < 0)
-    h += 360;
-
-  l = (cmax + cmin) / 2;
-  s = delta == 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
-  s = +(s * 100).toFixed(1);
-  l = +(l * 100).toFixed(1);
-
-  return {h, s, l}
-}
-
-function HSLToHex(hsl) {
-  var {h, s, l} = hsl
-  s /= 100;
-  l /= 100;
-
-  let c = (1 - Math.abs(2 * l - 1)) * s,
-      x = c * (1 - Math.abs((h / 60) % 2 - 1)),
-      m = l - c/2,
-      r = 0,
-      g = 0, 
-      b = 0; 
-
-  if (0 <= h && h < 60) {
-    r = c; g = x; b = 0;
-  } else if (60 <= h && h < 120) {
-    r = x; g = c; b = 0;
-  } else if (120 <= h && h < 180) {
-    r = 0; g = c; b = x;
-  } else if (180 <= h && h < 240) {
-    r = 0; g = x; b = c;
-  } else if (240 <= h && h < 300) {
-    r = x; g = 0; b = c;
-  } else if (300 <= h && h < 360) {
-    r = c; g = 0; b = x;
-  }
-  // Having obtained RGB, convert channels to hex
-  r = Math.round((r + m) * 255).toString(16);
-  g = Math.round((g + m) * 255).toString(16);
-  b = Math.round((b + m) * 255).toString(16);
-
-  // Prepend 0s, if necessary
-  if (r.length == 1)
-    r = "0" + r;
-  if (g.length == 1)
-    g = "0" + g;
-  if (b.length == 1)
-    b = "0" + b;
-
-  return "#" + r + g + b;
+  return colors.map(function(hex) {
+    var color = Color(hex)
+    color.rotate(amount)
+    return color.hexString()
+  })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
+        "color": "^0.11.3",
         "mersenne-twister": "^1.1.0"
       },
       "devDependencies": {
@@ -468,6 +469,45 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "integrity": "sha512-Ajpjd8asqZ6EdxQeqGzU5WBhhTfJ/0cA4Wlbre7e5vXfmDSmda7Ov6jeKoru+b0vHcb1CqvuroTHp5zIWzhVMA==",
+      "dependencies": {
+        "clone": "^1.0.2",
+        "color-convert": "^1.3.0",
+        "color-string": "^0.3.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha512-sz29j1bmSDfoAxKIEU6zwoIZXN6BrFbAMIhfYCNyiZXBDuU/aiHlN84lp/xDzL2ubyFhLDobHIlU1X70XRrMDA==",
+      "dependencies": {
+        "color-name": "^1.0.0"
       }
     },
     "node_modules/combine-source-map": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "license": "ISC",
   "dependencies": {
+    "color": "^0.11.3",
     "mersenne-twister": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This reverts commit d923914fda6a8795f74c2e66134f73cd72070667.

It seems that the implementation of `hueShift` is slightly different in this commit than before and therefore produces slightly different colors as before. Reverting so that we can fix this bug.