### PR TITLE
chore: fixes critical dependency version elliptic by upgrading browserfy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "mersenne-twister": "^1.1.0"
       },
       "devDependencies": {
-        "browserify": "^17.0.0"
+        "browserify": "^17.0.1"
       },
       "engines": {
         "node": "^18.16 || >=20"
@@ -206,10 +206,11 @@
       }
     },
     "node_modules/browserify": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.0.tgz",
-      "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.1.tgz",
+      "integrity": "sha512-pxhT00W3ylMhCHwG5yfqtZjNnFuX5h2IJdaBfSo4ChaaBsIp9VLrEMQ1bHV+Xr1uLPXuNDDM1GlJkjli0qkRsw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert": "^1.4.0",
         "browser-pack": "^6.0.1",
@@ -227,7 +228,7 @@
         "duplexer2": "~0.1.2",
         "events": "^3.0.0",
         "glob": "^7.1.0",
-        "has": "^1.0.0",
+        "hasown": "^2.0.0",
         "htmlescape": "^1.1.0",
         "https-browserify": "^1.0.0",
         "inherits": "~2.0.1",
@@ -755,10 +756,11 @@
       }
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -816,10 +818,14 @@
       "dev": true
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-assigned-identifiers": {
       "version": "1.2.0",
@@ -961,6 +967,19 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hmac-drbg": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mersenne-twister": "^1.1.0"
   },
   "devDependencies": {
-    "browserify": "^17.0.0"
+    "browserify": "^17.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This PR addresses a critical security vulnerability in the `elliptic` package (CVE-2023-49276), which is a transitive dependency through `browserify`. The vulnerability is identified in [Security Advisory #8](https://github.com/MetaMask/jazzicon/security/dependabot/8).

## Changes
- Upgraded `browserify` from `^17.0.0` to `^17.0.1`
- This update includes the patched version of `elliptic` (6.6.1) which fixes the vulnerability

## Dependency Path
```
browserify@17.0.1
└─┬ crypto-browserify@3.12.0
  ├─┬ browserify-sign@4.2.2
  │ └── elliptic@6.6.1
  └─┬ create-ecdh@4.0.4
    └── elliptic@6.6.1
```

## Testing
- Verified the demo build continues to work: `npm run build-demo`
- Confirmed the security vulnerability is resolved
- Package functionality remains unchanged as this only affects dev dependencies

## Screenshots

### Before

<img width="1415" alt="Screenshot 2025-03-19 at 12 26 39 PM" src="https://github.com/user-attachments/assets/c97bd33f-be8c-46fa-b0e4-f714ba8d6d7a" />


### After

<img width="1415" alt="Screenshot 2025-03-19 at 12 22 16 PM" src="https://github.com/user-attachments/assets/2be357ed-04a7-41f3-91d5-1dd717f25b5e" />


## Security
This update resolves a critical severity vulnerability that could potentially allow attackers to recover private keys through a timing attack on ECDSA signatures.

## Notes
- This change only affects development dependencies and does not impact production builds of projects using @metamask/jazzicon
